### PR TITLE
Update dependent-dropdown.js

### DIFF
--- a/js/dependent-dropdown.js
+++ b/js/dependent-dropdown.js
@@ -86,11 +86,11 @@
             $el.trigger('depdrop.error', [id, $("#" + id).val(), initVal]);
         };
         settings['complete'] = function () {
-            $el.trigger('depdrop.afterChange', [id, $("#" + id).val(), initVal]);
             callBack();
             if (vLoading) {
                 $el.removeClass(vLoadingClass);
             }
+            $el.trigger('depdrop.afterChange', [id, $("#" + id).val(), initVal]);
         };
         return settings;
     };


### PR DESCRIPTION
When using together with other, 3rd party selects (i.e. https://github.com/cakebake/yii2-bootstrap-select), I need to trigger the refrest of the select after DepDrop change completes. But the event trigger needs to be after the loading class removal, as otherwise the loading class remains on the select for some reason.
