### PR TITLE
Don't force dropdown value

### DIFF
--- a/js/dependent-dropdown.js
+++ b/js/dependent-dropdown.js
@@ -15,7 +15,7 @@
         },
         addOption = function ($el, id, name, sel) {
             var settings = {value: id, text: name};
-            if (id === sel && sel !== null) {
+            if (id.toString() === sel && sel !== null) {
                 settings.selected = "selected";
             }
             $("<option/>", settings).appendTo($el);
@@ -125,7 +125,7 @@
                             $el.find('option[value=""]').attr('disabled', 'disabled');
                         }
                         if (data.output.length !== 0) {
-                            $el.val(selected).removeAttr('disabled');
+                            $el.removeAttr('disabled');
                         }
                     }
                     optCount = $el.find('option').length;


### PR DESCRIPTION
I found that, when the options of a dropdown were updated, the selected value would persist even if it didn't exist among the new options.
This would lead to an empty, non-existent option being selected whereas I would expect the placeholder (or the first element if no placeholder exists) to be selected.

Setting the dropdown value with .val() on line 128 doesn't seem to be necessary if the returned option values are first converted to strings on line 18. This ensures that when the AJAX-call returns numeric values, they can still match the previous value, which is always a string.