### PR TITLE
fixed idParam checking

### DIFF
--- a/js/dependent-dropdown.js
+++ b/js/dependent-dropdown.js
@@ -159,7 +159,7 @@
                 data = {};
             }
             $.each(data, function (i, groups) {
-                if (groups[idParam]) {
+                if (typeof groups[idParam] !== 'undefined') {
                     options = groups.options || {};
                     addOption($select, groups[idParam], groups[nameParam], defVal, options);
                 }


### PR DESCRIPTION
Sometimes we have id equal to zero, e.g. {"output" : [{"id":0, "name" : "Select All", {"id": 1, "name" : "Male", {"id" : 2, "name" : "Female"}}]. 