### PR TITLE
Add property emptyMsg

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ View the [plugin documentation](http://plugins.krajee.com/dependent-dropdown) an
   ```
   {group-name: {id: <option-value>, name: <option-name>}}
   ```
+  
+  When no data is available for a specific situation (like error), you can send a custom emptyMsg
+
+  ```
+   {emptyMsg: '<your message>'}
+  ```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ View the [plugin documentation](http://plugins.krajee.com/dependent-dropdown) an
   {group-name: {id: <option-value>, name: <option-name>}}
   ```
   
-  When no data is available for a specific situation (like error), you can send a custom emptyMsg
+  When no data is available for a specific situation (like an backend error), you can send a custom emptyMsg
 
   ```
    {emptyMsg: '<your message>'}

--- a/js/dependent-dropdown.js
+++ b/js/dependent-dropdown.js
@@ -123,20 +123,19 @@
                     if (!isEmpty(data.emptyMsg)) {
                         vNullMsg = data.emptyMsg;
                     }
-                    if (isEmpty(data)) {
-                        addOption($el, '', vNullMsg, '');
+                    if (isEmpty(data) || isEmpty(data.output) || Object.keys(data.output).length == 0) {
+                        $el.html('');
+                        addOption($el, 0, vNullMsg, '');
                     }
                     else {
                         $el.html(self.getSelect(data.output, vDefault, selected));
                         if ($el.find('optgroup').length > 0) {
                             $el.find('option[value=""]').attr('disabled', 'disabled');
                         }
-                        if (data.output) {
-                            if (selected && $.isArray(selected) && $el.attr('multiple')) {
-                                $el.val(selected);
-                            }
-                            $el.removeAttr('disabled');
+                        if (selected && $.isArray(selected) && $el.attr('multiple')) {
+                            $el.val(selected);
                         }
+                        $el.removeAttr('disabled');
                     }
                     optCount = $el.find('option').length;
                     if ($el.find('option[value=""]').length > 0) {

--- a/js/dependent-dropdown.js
+++ b/js/dependent-dropdown.js
@@ -120,6 +120,9 @@
                 },
                 success: function (data) {
                     selected = isEmpty(data.selected) ? (self.initVal === false ? null : self.initVal): data.selected;
+                    if (!isEmpty(data.emptyMsg)) {
+                        vNullMsg = data.emptyMsg;
+                    }
                     if (isEmpty(data)) {
                         addOption($el, '', vNullMsg, '');
                     }


### PR DESCRIPTION
Added possibility to set a custom emptyMsg through Ajax (for example to show a server error message). Updated readme.md with example on how to use.
Fixed emptyMsg not being shown in a Select2 widget by setting id for message to 0 instead of empty string.