### PR TITLE
When dependency is not ready, do not trigger ajax

### DIFF
--- a/js/dependent-dropdown.js
+++ b/js/dependent-dropdown.js
@@ -118,6 +118,8 @@
                 $el = $('#' + depends[j]);
                 type = $el.attr('type');
                 value[j] = (type === "checkbox" || type === "radio") ? $el.prop('checked') : $el.val();
+                if(value[j] == '') return;
+                if(value[j] == $el.data('loadingText')) return;
             }
             self.processDep(self.$element, $elCurr.attr('id'), value, depends);
         },


### PR DESCRIPTION
If dependency is not ready, do not trigger ajax. It can improve the web performance.