### PR TITLE
In case of paramValue is zero currently treated as optgroup for example {"output":[{"id":0,"name":"New"},{"id":1,"name":"Used"}],"selected":""}

### DIFF
--- a/js/dependent-dropdown.js
+++ b/js/dependent-dropdown.js
@@ -213,7 +213,7 @@
                 data = {};
             }
             $.each(data, function (i, groups) {
-                if (groups[idParam]) {
+                if (groups[idParam].length !== 0) {
                     options = groups[self.optionsParam] || {};
                     self.createOption($select, groups[idParam], groups[nameParam], defVal, options);
                 } else {


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.